### PR TITLE
[ADD]商品一覧ページと商品ページの記述/ルーティングの変更

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,7 +1,15 @@
 class Public::ItemsController < ApplicationController
   def index
+    @items = Item.all
   end
 
   def show
+    @item = Item.find(params[:id]) 
+  end
+  
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :price, :explanation, :selling_status)
   end
 end

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,2 +1,20 @@
-<h1>Public::Items#index</h1>
-<p>Find me in app/views/public/items/index.html.erb</p>
+<div class="row">
+  <div class="col-2">
+		
+	</div>
+
+<div class="row">
+ <h2>商品一覧</h2><p>(全<%= @items.count %>件)</p>
+  <div>
+  <% @items.each do |item| %>
+ 
+   <p><%= item.name %></p>
+   <p>¥<%= item.price %></p>
+ 
+  <% end %>
+  </div>
+ </div>
+</div>
+
+
+

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,2 +1,10 @@
-<h1>Public::Items#show</h1>
-<p>Find me in app/views/public/items/show.html.erb</p>
+<div class="row">
+  <div class="col-xs-2">
+		<%= render 'items/sidebar', genres: @genres %>
+	</div>
+	<div class="col-xs-10">
+	 <p><%= item.name %></p>
+	 <p><%= item.explanation %></p>
+   <p>¥<%= item.price %></p>
+	</div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ devise_for :customers,skip:[:password],controllers:{
   get "home/about"=>"homes#about"
   get "search" => "searches#search"
 
+ scope module: :public do
    resources :customers, only: [:show, :edit, :update] do
      get :unsubscribe
      get :withdraw
@@ -36,4 +37,5 @@ devise_for :customers,skip:[:password],controllers:{
    end
    resources :items, only: [:index, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  end
  end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,13 +1,3 @@
 const { environment } = require('@rails/webpacker')
 
 module.exports = environment
-
-const webpack = require('webpack')
-environment.plugins.prepend(
-  'Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery/src/jquery',
-    jQuery: 'jquery/src/jquery',
-    Popper: 'popper.js'
-  })
-)


### PR DESCRIPTION
ルーティングで一部大きな変更をしました。顧客側のルート記述が間違っていたため、顧客側ページへ遷移できないエラーが発生していました。具体的に顧客側のresources達をscope module :public do ~ endで囲むことでURLはテーブル詳細設計書の通りかつ、publicファイルの中のコントローラーを利用できるようにしました。